### PR TITLE
fix: Fix the unexpected error issue where the parmas parameter value is undefined

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -16,7 +16,7 @@ function formatParams (queryKey: string, value: any): string[] {
   queryKey = queryKey.replace(/=/g, '')
   let result: string[] = []
 
-  switch (value.constructor) {
+  switch (value && value.constructor) {
     case String:
     case Number:
     case Boolean:


### PR DESCRIPTION
# 发生什么事情了
在我们的h5项目中，我使用了vue-jsonp，它的parmas数据是这样子的
`{
userid: 111,
openid: undefined
}`
当执行formatParams函数时，它会产生如下报错：
`TypeError: Cannot read property 'constructor' of undefined`

# 分析原因

这块时没有做兜底措施，本次修改已经处理好当value类型为any的时候，可能会出现null或undefined的情况